### PR TITLE
fix for JPEGs from Nikon D7100

### DIFF
--- a/src/xvjpeg.c
+++ b/src/xvjpeg.c
@@ -851,7 +851,11 @@ METHODDEF boolean  xv_process_app1(cinfo)
     exifInfo = (byte *) malloc((size_t) length);
     exifInfoSize = 0;
   }
-  else exifInfo = (byte *) realloc(exifInfo, exifInfoSize + length);
+  else {
+    /* one APP1 data struct only, ignore extra stuff */
+    while (length-- > 0)
+      (void)j_getc(cinfo);
+  }
   if (!exifInfo) FatalError("out of memory in xv_process_app1 (EXIF info)");
   
   sp = exifInfo + exifInfoSize;


### PR DESCRIPTION
This is taken from a patch to xv that we have in OpenBSD ports originally written by @marcespie

Nikon D7100 generates JPEG files with multiple APP1 structs; they can be read OK with xv but if the file is edited, an attempt to save it will fail. Sample files (marked "camera original") showing the problem at https://www.kenrockwell.com/nikon/d7100.htm e.g. https://www.kenrockwell.com/nikon/d7100/sample-images/D71_0346.JPG

The original patch is longer (touching xv.h, xvdir.c, xvjpeg.c) as it adds a small framework for reporting error messages, I skipped that to keep this PR to just the relevant part, if they're of interest you can find the other patches in https://github.com/openbsd/ports/tree/master/graphics/xv/patches