### PR TITLE
fix segv seen with some corrupt gif file

### DIFF
--- a/src/xvgif.c
+++ b/src/xvgif.c
@@ -75,6 +75,7 @@ static boolean Interlace, HasGlobalColormap;
 static byte *RawGIF;		/* The heap array to hold it, raw */
 static byte *Raster;		/* The raster data stream, unblocked */
 static byte *pic8;
+static size_t rasterSize;
 
     /* The hash table used by the decompressor */
 static int Prefix[4096];
@@ -145,7 +146,8 @@ int LoadGIF(fname, pinfo)
 
   /* the +256's are so we can read truncated GIF files without fear of
      segmentation violation */
-  if (!(dataptr = RawGIF = (byte *) calloc((size_t) filesize+256, (size_t) 1)))
+  rasterSize = filesize+256;
+  if (!(Raster = (byte *) calloc(rasterSize, (size_t) 1)))
     FatalError("LoadGIF: not enough memory to read GIF file");
 
   if (!(Raster = (byte *) calloc((size_t) filesize+256,(size_t) 1)))
@@ -796,6 +798,8 @@ static int readCode()
   int RawCode, ByteOffset;
 
   ByteOffset = BitOffset / 8;
+  if (ByteOffset >= rasterSize-2)
+    return 0;
   RawCode = Raster[ByteOffset] + (Raster[ByteOffset + 1] << 8);
   if (CodeSize >= 8)
     RawCode += ( ((int) Raster[ByteOffset + 2]) << 16);


### PR DESCRIPTION
This has been carried in OpenBSD ports for years (added in
https://github.com/openbsd/ports/commit/9282bea250be7880aba70f1100813c618231f32b)
unfortunately I don't have more details about the original problem.