### PR TITLE
Include <stdint.h> in xvtiff.c so that uint32_t is defined.

### DIFF
--- a/src/xvtiff.c
+++ b/src/xvtiff.c
@@ -13,7 +13,7 @@
 #ifdef HAVE_TIFF
 
 #include "tiffio.h"     /* has to be after xv.h, as it needs varargs/stdarg */
-
+#include <stdint.h>
 
 /* Portions fall under the following copyright:
  *


### PR DESCRIPTION
xv doesn't build for me without this (on Linux).