### PR TITLE
Fix build with link-time optimization

### DIFF
--- a/src/xv.c
+++ b/src/xv.c
@@ -6,7 +6,6 @@
 
 #define MAIN
 #define NEEDSTIME
-#define NEEDSDIR     /* for value of MAXPATHLEN */
 
 #include "xv.h"
 

--- a/src/xv.h
+++ b/src/xv.h
@@ -293,31 +293,26 @@
 
 
 
-#ifdef NEEDSDIR
-#  ifdef VMS
-#    include <descrip.h>
-#    include <stat.h>
-#    include "dirent.h"
+#ifdef VMS
+#  include <descrip.h>
+#  include <stat.h>
+#  include "dirent.h"
+#else
+#  ifdef NODIRENT
+#    include <sys/dir.h>
 #  else
-#    ifdef NODIRENT
-#      include <sys/dir.h>
-#    else
-#      include <dirent.h>
-#    endif
-
-#    if defined(SVR4) || defined(SYSV)
-#      include <fcntl.h>
-#    endif
-
-#    include <sys/param.h>
-#    include <sys/stat.h>
-
-#    if defined(__convex__) && defined (__STDC__)
-#      define S_IFMT  _S_IFMT
-#      define S_IFDIR _S_IFDIR
-#      define S_IFCHR _S_IFCHR
-#      define S_IFBLK _S_IFBLK
-#    endif
+#    include <dirent.h>
+#  endif
+#  if defined(SVR4) || defined(SYSV)
+#    include <fcntl.h>
+#  endif
+#  include <sys/param.h>
+#  include <sys/stat.h>
+#  if defined(__convex__) && defined (__STDC__)
+#    define S_IFMT  _S_IFMT
+#    define S_IFDIR _S_IFDIR
+#    define S_IFCHR _S_IFCHR
+#    define S_IFBLK _S_IFBLK
 #  endif
 #endif
 

--- a/src/xvbrowse.c
+++ b/src/xvbrowse.c
@@ -17,7 +17,6 @@
 
 #include "copyright.h"
 
-#define NEEDSDIR
 #include "xv.h"
 #include <unistd.h>   /* access() */
 

--- a/src/xvcut.c
+++ b/src/xvcut.c
@@ -47,7 +47,6 @@
  */
 
 
-#define  NEEDSDIR               /* for stat() */
 #include "copyright.h"
 #include "xv.h"
 

--- a/src/xvdir.c
+++ b/src/xvdir.c
@@ -21,7 +21,6 @@
 #include "copyright.h"
 
 #define NEEDSTIME      /* for CheckPoll */
-#define NEEDSDIR
 #include "xv.h"
 
 #include "bits/d_load"

--- a/src/xvfits.c
+++ b/src/xvfits.c
@@ -14,7 +14,6 @@
  * provided "as is" without express or implied warranty.
  */
 
-#define  NEEDSDIR /* for S_IRUSR|S_IWUSR */
 #include "xv.h"
 
 #define NCARDS    (36)

--- a/src/xvimage.c
+++ b/src/xvimage.c
@@ -30,7 +30,6 @@
  */
 /* #define ENABLE_FIXPIX_SMOOTH */   /* GRR 19980607:  moved into xv.h */
 
-#define  NEEDSDIR             /* for S_IRUSR|S_IWUSR */
 #include "copyright.h"
 
 #include "xv.h"

--- a/src/xvmgcsfx.c
+++ b/src/xvmgcsfx.c
@@ -60,7 +60,6 @@
  *  同様に書き込み時にも問題が生じるかもしれない。
  */
 
-#define  NEEDSDIR               /* for stat() */
 #include "xv.h"
 
 

--- a/src/xvpds.c
+++ b/src/xvpds.c
@@ -101,7 +101,6 @@
  * This software is provided "as is" without any express or implied warranty.
  */
 
-#define  NEEDSDIR       /* for S_IRUSR|S_IWUSR */
 #include "xv.h"
 
 #ifdef HAVE_PDS

--- a/src/xvpic2.c
+++ b/src/xvpic2.c
@@ -61,7 +61,6 @@
  */
 
 #define PIC2_IGNORE_UNUSED_FUNCTIONS
-#define NEEDSDIR
 
 #include "xv.h"
 #include <setjmp.h>

--- a/src/xvps.c
+++ b/src/xvps.c
@@ -13,7 +13,6 @@
 
 #include "copyright.h"
 
-#define NEEDSDIR
 #include "xv.h"
 
 #define PSWIDE 431

--- a/src/xvvd.c
+++ b/src/xvvd.c
@@ -4,8 +4,6 @@
  *          (virtual) directory.
  */
 
-#define NEEDSDIR
-
 #include "xv.h"
 
 #ifdef AUTO_EXPAND


### PR DESCRIPTION
When building with link-time optimization enabled, the compiler errors out due to some arrays being declared with different sizes in different compilation units. All of the problematic declarations are of character arrays of size `MAXPATHLEN` in `xv.h`, which is included by all of xv's source files.

However, the value of the token `MAXPATHLEN` varies depending on whether or not the token `NEEDSDIR` is defined at the time of xv.h's inclusion. If it is defined, `MAXPATHLEN` will be defined via system headers, typically to a value of 4096. If it is not defined, a default value of 256 is used. The `NEEDSDIR` mechanism was probably created to speed up compilation by not including files unnecessarily on the very old and slow systems that xv was originally written for, and is almost certainly unnecessary now. Hence, the fix for this issue is to get rid of `NEEDSDIR` altogether and just include the necessary files unconditionally.

Fixes #25.