### PR TITLE
xvjpeg.c: Fix a bad memory access on jpegs with inverted data

### DIFF
--- a/src/xvjpeg.c
+++ b/src/xvjpeg.c
@@ -693,13 +693,14 @@ L2:
     if (cinfo.saw_Adobe_marker) { /* assume inverted data */
       register byte *q = pic;
 
-      do {
+      while (q < pic_end) {
         register int cmy, k = 255 - q[3];
 
         if ((cmy = *q++ - k) < 0) { cmy = 0; } *p++ = cmy; /* R */
         if ((cmy = *q++ - k) < 0) { cmy = 0; } *p++ = cmy; /* G */
         if ((cmy = *q++ - k) < 0) { cmy = 0; } *p++ = cmy; /* B */
-      } while (++q <= pic_end);
+        q++;
+      }
     }
     else { /* assume normal data */
       register byte *q = pic;


### PR DESCRIPTION
This fixes the bad memory access below. I can provide the jpeg file privately if necessary.
There is a parallel section that probably needs a similar change, but I have no files that enter that section of code, so I left it alone. I can change it also if you want.

``==43845==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7f23a205f003 at pc 0x000000647586 bp 0x7ffd0176a640 sp 0x7ffd0176a638
READ of size 1 at 0x7f23a205f003 thread T0
    #0 0x647585 in LoadJFIF /u/git/xv5/src/xvjpeg.c:697
    #1 0x4c03e8 in ReadPicFile /u/git/xv5/src/xv.c:3378
    #2 0x4bbbda in openPic /u/git/xv5/src/xv.c:2624
    #3 0x4c2f55 in openFirstPic /u/git/xv5/src/xv.c:3845
    #4 0x4c33e6 in mainLoop /u/git/xv5/src/xv.c:3964
    #5 0x4abae0 in main /u/git/xv5/src/xv.c:1140
    #6 0x7f23a4839087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #7 0x7f23a483914a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #8 0x409a44 in _start (/usr/local/bin/xv+0x409a44) (BuildId: 9e6c07dd1eee9aa7e31a94c00f7251e1550802cd)

0x7f23a205f003 is located 3 bytes after 1075200-byte region [0x7f23a1f58800,0x7f23a205f000)
allocated by thread T0 here:
    #0 0x7f23a56f7997 in malloc (/lib64/libasan.so.8+0xf7997) (BuildId: 79824421bd82bb3ef4addf048e1265e2a93cfc64)
    #1 0x647244 in LoadJFIF /u/git/xv5/src/xvjpeg.c:657
    #2 0x4c03e8 in ReadPicFile /u/git/xv5/src/xv.c:3378
    #3 0x4bbbda in openPic /u/git/xv5/src/xv.c:2624
    #4 0x4c2f55 in openFirstPic /u/git/xv5/src/xv.c:3845
    #5 0x4c33e6 in mainLoop /u/git/xv5/src/xv.c:3964
    #6 0x4abae0 in main /u/git/xv5/src/xv.c:1140
    #7 0x7f23a4839087 in __libc_start_call_main (/lib64/libc.so.6+0x2a087) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #8 0x7f23a483914a in __libc_start_main_alias_1 (/lib64/libc.so.6+0x2a14a) (BuildId: 77c77fee058b19c6f001cf2cb0371ce3b8341211)
    #9 0x409a44 in _start (/usr/local/bin/xv+0x409a44) (BuildId: 9e6c07dd1eee9aa7e31a94c00f7251e1550802cd)
