### PR TITLE
xvjpeg.c,xvpng.c: Fix gcc warnings on -Wclobbered

### DIFF
--- a/src/xv.c
+++ b/src/xv.c
@@ -1446,8 +1446,8 @@ static void parseResources(int argc, char **argv)
   if (rd_flag("pic2split"))      pic2split   = def_int;
 #endif
   if (rd_flag("popupKludge"))    winCtrPosKludge = def_int;
-  if (rd_str ("print"))          strncpy(printCmd, def_str,
-					 (size_t) PRINTCMDLEN);
+  if (rd_str ("print"))          { strncpy(printCmd, def_str, (size_t) PRINTCMDLEN);
+                                   printCmd[ PRINTCMDLEN - 1 ] = '\0'; }
   if (rd_flag("pscompress"))     pscomp      = def_int;
   if (rd_flag("pspreview"))      preview     = def_int;
   if (rd_flag("quick24") && def_int)  conv24 = CONV24_FAST;

--- a/src/xvbrowse.c
+++ b/src/xvbrowse.c
@@ -3710,6 +3710,7 @@ static void genIcon(BROWINFO *br, BFIL *bf)
     if (UncompressFile(uncName, uncompname, filetype)) {
       filetype = ReadFileType(uncompname);
       strncpy(readname, uncompname, sizeof(readname) - 1);
+      readname[ sizeof(readname) - 1 ] = '\0';
     }
     else {
       sprintf(str, "Couldn't uncompress file '%s'", bf->name);

--- a/src/xvjpeg.c
+++ b/src/xvjpeg.c
@@ -507,16 +507,20 @@ int LoadJFIF(char *fname, PICINFO *pinfo, int quick)
   struct my_error_mgr              jerr;
   JSAMPROW                         rowptr[1];
   FILE                            *fp;
-  const char                      *colorspace_name = "Color";
+  const char                      *colorspace_name;
   byte                            *pic;
   long                             filesize;
   int                              i,w,h,bperpix,bperline,count;
 
 
+  /* Initialize variables below instead of in the declarations above to avoid the warning */
+  /* variable might be clobbered by 'longjmp' or 'vfork' [-Wclobbered] */
+
   fbasename = BaseName(fname);
   pic       = (byte *) NULL;
   comment   = (char *) NULL;
   exifInfo  = (byte *) NULL;
+  colorspace_name = "Color";
 
   pinfo->type  = PIC8;
 
@@ -551,7 +555,6 @@ L1:
 
     return 0;
   }
-
 
   jpeg_create_decompress(&cinfo);
   jpeg_set_marker_processor(&cinfo, JPEG_COM, xv_process_comment);

--- a/src/xvpds.c
+++ b/src/xvpds.c
@@ -650,21 +650,28 @@ int LoadPDS(char *fname, PICINFO *pinfo)
   *infobuff='\0';
   if (*spacecraft) {
     strncat(infobuff, spacecraft, sizeof(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
   }
 
   if (*target) {
     strncat(infobuff, ", ", sizeof(infobuff) - strlen(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
     strncat(infobuff, target, sizeof(infobuff) - strlen(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
   }
 
   if (*filtname) {
     strncat(infobuff, ", ", sizeof(infobuff) - strlen(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
     strncat(infobuff, filtname, sizeof(infobuff) - strlen(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
   }
 
   if (*itime) {
     strncat(infobuff, ", ", sizeof(infobuff) - strlen(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
     strncat(infobuff, itime, sizeof(infobuff) - strlen(infobuff) - 1);
+    infobuff[ sizeof(infobuff) - 1 ] = '\0';
   }
 
   SetISTR(ISTR_WARNING, "%s", infobuff);

--- a/src/xvpng.c
+++ b/src/xvpng.c
@@ -431,7 +431,7 @@ int WritePNG(FILE *fp, byte *pic, int ptype, int w, int h, byte *rmap, byte *gma
   byte        r1[256], g1[256], b1[256];  /* storage for deduped palette */
   byte        pc2nc[256];  /* for duplicated-color remapping (1st level) */
   byte        remap[256];  /* for bw/grayscale remapping (2nd level) */
-  int         i, j, numuniqcols=0, filter, linesize, pass;
+  int         i, j, numuniqcols, filter, linesize, pass;
   byte       *p, *png_line;
   char        software[256];
   char       *savecmnt;
@@ -495,8 +495,9 @@ int WritePNG(FILE *fp, byte *pic, int ptype, int w, int h, byte *rmap, byte *gma
 
   _interlace_type = interCB.val ? PNG_INTERLACE_ADAM7 : PNG_INTERLACE_NONE;
 
-  linesize = 0;   /* quiet a compiler warning */
+  numuniqcols = 0;
 
+  linesize = 0;   /* quiet a compiler warning */
 
   /* GRR 20070331:  remap palette to eliminate duplicated colors (as in
    *   xvgifwr.c) */

--- a/src/xvpng.c
+++ b/src/xvpng.c
@@ -495,9 +495,8 @@ int WritePNG(FILE *fp, byte *pic, int ptype, int w, int h, byte *rmap, byte *gma
 
   _interlace_type = interCB.val ? PNG_INTERLACE_ADAM7 : PNG_INTERLACE_NONE;
 
-  numuniqcols = 0;
-
   linesize = 0;   /* quiet a compiler warning */
+  numuniqcols = 0;
 
   /* GRR 20070331:  remap palette to eliminate duplicated colors (as in
    *   xvgifwr.c) */

--- a/src/xvtext.c
+++ b/src/xvtext.c
@@ -389,6 +389,7 @@ int TextView(const char *fname)
 #endif
 
   strncpy(rfname, filename, sizeof(rfname) - 1);
+  rfname[ sizeof(rfname) - 1 ] = '\0';
 
   /* see if this file is compressed.  if it is, uncompress it, and view
      the uncompressed version */


### PR DESCRIPTION
Initializations in declarations in functions with setjmp() trigger this warning. Initializations have to be changed to assignments after the declarations. The other changes fix some warnings about strncpy truncation by ensuring that the destination is null terminated.
This should resolve https://github.com/jasper-software/xv/issues/28