### PR TITLE
xv.c, xvimage.c, xvjpeg.c: Ensure that exifInfo is freed.

### DIFF
--- a/src/xv.c
+++ b/src/xv.c
@@ -214,7 +214,6 @@ int main(int argc, char **argv)
 
   picComments = (char *) NULL;
 
-  if (picExifInfo) free(picExifInfo);
   picExifInfo = (byte *) NULL;
   picExifInfoSize = 0;
 
@@ -2201,6 +2200,7 @@ static int openPic(int filenum)
   /* init important fields of pinfo */
   pinfo.pic = (byte *) NULL;
   pinfo.comment = (char *) NULL;
+  pinfo.exifInfo = (byte *) NULL;
   pinfo.numpages = 1;
   pinfo.pagebname[0] = '\0';
 
@@ -2652,6 +2652,10 @@ ms_auto_no:
       free(pinfo.comment);
     }
     pinfo.comment = (char *) NULL;
+    if (pinfo.exifInfo) {
+      free(pinfo.exifInfo);
+    }
+    pinfo.exifInfo = (byte *) NULL;
     goto FAILED;
   }
 
@@ -2703,6 +2707,10 @@ ms_auto_no:
       free(pinfo.comment);
     }
     pinfo.comment = (char *) NULL;
+    if (pinfo.exifInfo) {
+      free(pinfo.exifInfo);
+    }
+    pinfo.exifInfo = (byte *) NULL;
     Warning();
     goto FAILED;
   }

--- a/src/xvimage.c
+++ b/src/xvimage.c
@@ -1448,6 +1448,10 @@ void KillOldPics(void)
   if (picComments) free(picComments);
   picComments = (char *) NULL;
   ChangeCommentText();
+
+  if (picExifInfo) free(picExifInfo);
+  picExifInfo = (byte *) NULL;
+  picExifInfoSize = 0;
 }
 
 

--- a/src/xvjpeg.c
+++ b/src/xvjpeg.c
@@ -77,11 +77,11 @@ static    int          writeJFIF          PARM((FILE *, byte *, int,int,int));
 
 
 /*** local variables ***/
-static char *filename;
-static const char *fbasename;
-static char *comment;
-static byte *exifInfo;
-static int   exifInfoSize;   /* not a string => must track size explicitly */
+static char *filename = NULL;
+static const char *fbasename = NULL;
+static char *comment = NULL;
+static byte *exifInfo = NULL;
+static int   exifInfoSize = 0;   /* not a string => must track size explicitly */
 static int   colorType;
 
 static DIAL  qDial, smDial;
@@ -515,7 +515,11 @@ int LoadJFIF(char *fname, PICINFO *pinfo, int quick)
 
   fbasename = BaseName(fname);
   pic       = (byte *) NULL;
+
+  if (comment) free(comment);
   comment   = (char *) NULL;
+
+  if (exifInfo) free(exifInfo);
   exifInfo  = (byte *) NULL;
 
   pinfo->type  = PIC8;


### PR DESCRIPTION
This fixes a memory leak reported by LeakSanitizer in LoadJFIF.