### PR TITLE
xvexif.c ExifComment(): Call exif_data_free() to fix memory leak.

### DIFF
--- a/src/xvexif.c
+++ b/src/xvexif.c
@@ -51,12 +51,14 @@ char* ExifComment(char* comment) {
   char* fullComment = malloc(size);
   if (fullComment == NULL) {
     fprintf(stderr, "could not allocate memory for exif comment\n");
+    exif_data_free(exifData);
     return NULL;
   }
 
   strcpy(fullComment, comment ? comment : "");
   strcat(fullComment, exifTitle);
   exif_data_foreach_content(exifData, exifAddContent, fullComment);
+  exif_data_free(exifData);
   return fullComment;
 }
 


### PR DESCRIPTION
This patch fixes a memory leak reported by the address sanitizer.
    #6 0x00000056fca1 in ExifComment /u/git/xv5/src/xvexif.c:45
    #7 0x0000006e57d6 in ChangeCommentText /u/git/xv5/src/xvtext.c:550
    #8 0x0000004b8520 in openPic /u/git/xv5/src/xv.c:2865